### PR TITLE
Update Scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "npx tsc",
-    "start": "bun run --watch index.ts",
-    "dev": "concurrently \"npx tsc --watch\" \"nodemon -q build/index.js\""
+    "start": "bun run --watch index.ts"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
### TL;DR

This pull request updates the scripts section in package.json, removing the 'build' and 'dev' scripts, and leaving 'start' as is.

### What changed?

The 'build' and 'dev' scripts have been removed from the scripts section of package.json. The 'start' script's command has not been modified and remains the same.

### How to test?

To test this, check out to this branch and run 'npm start' to see if the app starts as expected without any errors.

### Why make this change?

These changes simplify the script commands in package.json. This is part of a larger effort to streamline the build and start processes.

---

Build and development scripts are deprecated 